### PR TITLE
feat(aws-sdk): upgrade aws-sdk to v3

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-@fjandin:registry=https://registry.npmjs.org
+@pleo-io:registry=https://npm.pkg.github.com
 loglevel = warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.0.0]
+
+### Added
+- Upgraded from aws-sdk v2 to client specific v3 libraries (@aws-sdk/client-dynamodb & @aws-sdk/client-secrets-manager)
+
 ## [1.7.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Install
 
-`yarn add @fjandin/config-man`
+`yarn add @pleo-io/config-man`
 
 ## Initialize
 
@@ -15,7 +15,7 @@ Add `[ProjectRoot]/config-man.json` file
 ```
 
 ```ts
-import * as configMan from '@fjandin/config-man'
+import * as configMan from '@pleo-io/config-man'
 
 configMan.init({
     cwd: __dirname,

--- a/opslevel.yml
+++ b/opslevel.yml
@@ -1,0 +1,21 @@
+---
+version: 1
+service:
+  name: Config Man NodeJS Configuration Manager
+  lifecycle: generally_available
+  tier:
+  product:
+  owner: localisation
+  language: TypeScript
+  description: NodeJS Configuration Manager
+  aliases:
+    - "@pleo-io/config-man"
+  tags:
+  - key: type
+    value: library
+  repositories:
+  - name: pleo-io/config-man
+    path: "/"
+    provider: github
+  tools:
+  dependencies:

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "@fjandin/config-man",
+  "name": "@pleo-io/config-man",
   "version": "2.0.0",
   "description": "Config manager",
   "main": "index.js",
   "author": "René Bischoff <rene.bischoff@gmail.com> (https://github.com/fjandin)",
-  "homepage": "https://github.com/fjandin/config-man",
+  "homepage": "https://github.com/pleo-io/config-man",
   "readme": "README.md",
   "repository": {
     "type": "git",
-    "url": "https://github.com/fjandin/config-man.git"
+    "url": "https://github.com/pleo-io/config-man.git"
   },
   "bugs": {
-    "url": "https://github.com/fjandin/config-man/issues",
+    "url": "https://github.com/pleo-io/config-man/issues",
     "email": "project@hostname.com"
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fjandin/config-man",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "description": "Config manager",
   "main": "index.js",
   "author": "René Bischoff <rene.bischoff@gmail.com> (https://github.com/fjandin)",
@@ -17,7 +17,7 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "peer": "yarn add --peer --frozen-lockfile aws-sdk@^2.895.0",
+    "peer": "yarn add --peer --frozen-lockfile @aws-sdk/client-secrets-manager@^3.379.0 @aws-sdk/client-dynamodb@^3.379.0",
     "lint": "eslint src --ext .ts,.js",
     "lint:fix": "eslint src --ext .ts,.js --fix",
     "typecheck": "tsc --noEmit",
@@ -46,6 +46,7 @@
     "typescript": "^4.2.4"
   },
   "peerDependencies": {
-    "aws-sdk": "^2.895.0"
+    "@aws-sdk/client-dynamodb": "^3.379.0",
+    "@aws-sdk/client-secrets-manager": "^3.379.0"
   }
 }


### PR DESCRIPTION
This PR upgrades to `aws-sdk` v3 from v2. The upgrade involves using client specific libraries for secrets manager and dynamo db. This is required when using lambdas on Node 18 as `aws-sdk` is no longer available in the runtime.

Tested via unit tests & manual test via `yarn link`.