### PR TITLE
fix(package): add yarn install and build steps before publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,8 @@ jobs:
     release:
         name: Release
         runs-on: ubuntu-latest
-        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        needs: check
+        # if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        # needs: check
         steps:
             - name: Checkout code
               uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
 
             - name: Release
               run: |
-                  npx --package=@auto-it/git-tag --package=@auto-it/omit-release-notes --package=auto -- auto shipit
+                  npx --package=@auto-it/git-tag --package=@auto-it/omit-release-notes --package=auto -- auto shipit -vv
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.4--canary.5.8d8f77f.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @pleo-io/config-man@2.0.4--canary.5.8d8f77f.0
  # or 
  yarn add @pleo-io/config-man@2.0.4--canary.5.8d8f77f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
